### PR TITLE
prevent TLS mixed-content warning

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="description" content="the cloudyr project">
 
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ site.github.url }}/css/stylesheet.css">
+    <link rel="stylesheet" type="text/css" media="screen" href="/css/stylesheet.css">
 
     <title>the cloudyr project</title>
   </head>


### PR DESCRIPTION
When I view the site [using TLS](https://cloudyr.github.io/) the CSS file is not loaded because it is included via unsecured http (on Chrome). This change should fix the problem.